### PR TITLE
Fix conflict when trying to install both kSync and DAVx5

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,7 +419,7 @@
     <string name="exception_show_details">Show details</string>
 
     <!-- WebDAV accounts -->
-    <string name="webdav_authority" translatable="false">at.bitfire.davdroid.webdav</string>
+    <string name="webdav_authority" translatable="false">com.infomaniak.sync.webdav</string>
     <string name="webdav_mounts_title">WebDAV mounts</string>
     <string name="webdav_mounts_quota_used_available">Quota used: %1$s / available: %2$s</string>
     <string name="webdav_mounts_share_content">Share content</string>


### PR DESCRIPTION
Fixed the installation error INSTALL_FAILED_CONFLICTING_PROVIDER caused by the two apps using the same name for a new provider that wasn't present in the old version 3 of kSync